### PR TITLE
Allow non-interactive command to generate keys and mnemonic.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine3.14
+FROM python:3.9.17-alpine3.18
 
 WORKDIR /app
 
@@ -6,11 +6,9 @@ COPY requirements.txt setup.py ./
 
 COPY staking_deposit ./staking_deposit
 
-RUN apk add --update gcc libc-dev linux-headers zlib-dev
-
-RUN pip3 install -r requirements.txt
-
-RUN python3 setup.py install
+RUN apk add --update --no-cache gcc libc-dev linux-headers zlib-dev \
+    && pip3 install -r requirements.txt \
+    && python3 setup.py install
 
 ARG cli_command
 

--- a/staking_deposit/cli/existing_mnemonic.py
+++ b/staking_deposit/cli/existing_mnemonic.py
@@ -58,7 +58,6 @@ def validate_mnemonic(ctx: click.Context, param: Any, mnemonic: str) -> str:
     callback=captive_prompt_callback(
         lambda num: validate_int_range(num, 0, 2**32),
         lambda: load_text(['arg_validator_start_index', 'prompt'], func='existing_mnemonic'),
-        lambda: load_text(['arg_validator_start_index', 'confirm'], func='existing_mnemonic'),
     ),
     default=0,
     help=lambda: load_text(['arg_validator_start_index', 'help'], func='existing_mnemonic'),

--- a/staking_deposit/cli/generate_keys.py
+++ b/staking_deposit/cli/generate_keys.py
@@ -132,6 +132,7 @@ def generate_keys(ctx: click.Context, validator_start_index: int,
                   amount: int, eth1_withdrawal_address: HexAddress, **kwargs: Any) -> None:
     mnemonic = ctx.obj['mnemonic']
     mnemonic_password = ctx.obj['mnemonic_password']
+    mnemonic_path = ctx.obj.get('mnemonic_path')
     amounts = [amount] * num_validators
     folder = os.path.join(folder, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
     chain_setting = get_chain_setting(chain)
@@ -155,8 +156,7 @@ def generate_keys(ctx: click.Context, validator_start_index: int,
         raise ValidationError(load_text(['err_verify_keystores']))
     if not verify_deposit_data_json(deposits_file, credentials.credentials):
         raise ValidationError(load_text(['err_verify_deposit']))
+
     click.echo(load_text(['msg_creation_success']) + folder)
-    mnemonic_file = kwargs['mnemonic_file']
-    if mnemonic_file:
-        path = os.path.normpath(f'{os.getcwd()}/{mnemonic_file}')
-        click.echo(f'Your mnemonics can be found at: {path}')
+    if mnemonic_path:
+        click.echo(f'Your mnemonics can be found at: {mnemonic_path}')

--- a/staking_deposit/cli/generate_keys.py
+++ b/staking_deposit/cli/generate_keys.py
@@ -71,7 +71,7 @@ def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[
         ),
         jit_option(
             help=f'If this option are set, the generated mnemonic will be store in a destination file provided.',
-            param_decls='--mnemonic_dest_file',
+            param_decls='--mnemonic_file',
             type=click.Path(exists=False, file_okay=True, dir_okay=False),
         ),
         jit_option(
@@ -156,7 +156,7 @@ def generate_keys(ctx: click.Context, validator_start_index: int,
     if not verify_deposit_data_json(deposits_file, credentials.credentials):
         raise ValidationError(load_text(['err_verify_deposit']))
     click.echo(load_text(['msg_creation_success']) + folder)
-    mnemonic_dest_file = kwargs['mnemonic_dest_file']
-    if mnemonic_dest_file:
-        path = os.path.normpath(f'{os.getcwd()}/{mnemonic_dest_file}')
+    mnemonic_file = kwargs['mnemonic_file']
+    if mnemonic_file:
+        path = os.path.normpath(f'{os.getcwd()}/{mnemonic_file}')
         click.echo(f'Your mnemonics can be found at: {path}')

--- a/staking_deposit/cli/generate_keys.py
+++ b/staking_deposit/cli/generate_keys.py
@@ -70,6 +70,11 @@ def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[
             prompt=lambda: load_text(['num_validators', 'prompt'], func='generate_keys_arguments_decorator'),
         ),
         jit_option(
+            help=f'If this option are set, the generated mnemonic will be store in a destination file provided.',
+            param_decls='--mnemonic_dest_file',
+            type=click.Path(exists=False, file_okay=True, dir_okay=False),
+        ),
+        jit_option(
             default=os.getcwd(),
             help=lambda: load_text(['folder', 'help'], func='generate_keys_arguments_decorator'),
             param_decls='--folder',
@@ -96,9 +101,6 @@ def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[
             callback=captive_prompt_callback(
                 validate_password_strength,
                 lambda:load_text(['keystore_password', 'prompt'], func='generate_keys_arguments_decorator'),
-                lambda:load_text(['keystore_password', 'confirm'], func='generate_keys_arguments_decorator'),
-                lambda: load_text(['keystore_password', 'mismatch'], func='generate_keys_arguments_decorator'),
-                True,
             ),
             help=lambda: load_text(['keystore_password', 'help'], func='generate_keys_arguments_decorator'),
             hide_input=True,
@@ -154,4 +156,7 @@ def generate_keys(ctx: click.Context, validator_start_index: int,
     if not verify_deposit_data_json(deposits_file, credentials.credentials):
         raise ValidationError(load_text(['err_verify_deposit']))
     click.echo(load_text(['msg_creation_success']) + folder)
-    click.pause(load_text(['msg_pause']))
+    mnemonic_dest_file = kwargs['mnemonic_dest_file']
+    if mnemonic_dest_file:
+        path = os.path.normpath(f'{os.getcwd()}/{mnemonic_dest_file}')
+        click.echo(f'Your mnemonics can be found at: {path}')

--- a/staking_deposit/cli/new_mnemonic.py
+++ b/staking_deposit/cli/new_mnemonic.py
@@ -47,7 +47,7 @@ languages = get_first_options(MNEMONIC_LANG_OPTIONS)
 )
 @generate_keys_arguments_decorator
 def new_mnemonic(ctx: click.Context, mnemonic_language: str, **kwargs: Any) -> None:
-    ctx.obj = {}
+    ctx.obj = {} if ctx.obj is None else ctx.obj  # Create a new ctx.obj if it doesn't exist
     mnemonic = get_mnemonic(language=mnemonic_language, words_path=WORD_LISTS_PATH)
     mnemonic_file = ctx.params['mnemonic_file']
     if mnemonic_file:

--- a/staking_deposit/cli/new_mnemonic.py
+++ b/staking_deposit/cli/new_mnemonic.py
@@ -49,9 +49,9 @@ languages = get_first_options(MNEMONIC_LANG_OPTIONS)
 def new_mnemonic(ctx: click.Context, mnemonic_language: str, **kwargs: Any) -> None:
     mnemonic = get_mnemonic(language=mnemonic_language, words_path=WORD_LISTS_PATH)
 
-    mnemonic_dest_file = kwargs['mnemonic_dest_file']
-    if mnemonic_dest_file:
-        path = os.path.normpath(f'{os.getcwd()}/{mnemonic_dest_file}')
+    mnemonic_file = kwargs['mnemonic_file']
+    if mnemonic_file:
+        path = os.path.normpath(f'{os.getcwd()}/{mnemonic_file}')
         f = open(path, 'a')
         f.write(mnemonic)
         f.close()

--- a/staking_deposit/cli/new_mnemonic.py
+++ b/staking_deposit/cli/new_mnemonic.py
@@ -1,3 +1,4 @@
+import os
 import click
 from typing import (
     Any,
@@ -47,16 +48,24 @@ languages = get_first_options(MNEMONIC_LANG_OPTIONS)
 @generate_keys_arguments_decorator
 def new_mnemonic(ctx: click.Context, mnemonic_language: str, **kwargs: Any) -> None:
     mnemonic = get_mnemonic(language=mnemonic_language, words_path=WORD_LISTS_PATH)
-    test_mnemonic = ''
-    while mnemonic != reconstruct_mnemonic(test_mnemonic, WORD_LISTS_PATH):
-        click.clear()
-        click.echo(load_text(['msg_mnemonic_presentation']))
-        click.echo('\n\n%s\n\n' % mnemonic)
-        click.pause(load_text(['msg_press_any_key']))
 
+    mnemonic_dest_file = kwargs['mnemonic_dest_file']
+    if mnemonic_dest_file:
+        path = os.path.normpath(f'{os.getcwd()}/{mnemonic_dest_file}')
+        f = open(path, 'a')
+        f.write(mnemonic)
+        f.close()
+    else:
+        test_mnemonic = ''
+        while mnemonic != reconstruct_mnemonic(test_mnemonic, WORD_LISTS_PATH):
+            click.clear()
+            click.echo(load_text(['msg_mnemonic_presentation']))
+            click.echo('\n\n%s\n\n' % mnemonic)
+            click.pause(load_text(['msg_press_any_key']))
+
+            click.clear()
+            test_mnemonic = click.prompt(load_text(['msg_mnemonic_retype_prompt']) + '\n\n')
         click.clear()
-        test_mnemonic = click.prompt(load_text(['msg_mnemonic_retype_prompt']) + '\n\n')
-    click.clear()
     # Do NOT use mnemonic_password.
     ctx.obj = {'mnemonic': mnemonic, 'mnemonic_password': ''}
     ctx.params['validator_start_index'] = 0

--- a/staking_deposit/cli/new_mnemonic.py
+++ b/staking_deposit/cli/new_mnemonic.py
@@ -47,14 +47,15 @@ languages = get_first_options(MNEMONIC_LANG_OPTIONS)
 )
 @generate_keys_arguments_decorator
 def new_mnemonic(ctx: click.Context, mnemonic_language: str, **kwargs: Any) -> None:
+    ctx.obj = {}
     mnemonic = get_mnemonic(language=mnemonic_language, words_path=WORD_LISTS_PATH)
-
-    mnemonic_file = kwargs['mnemonic_file']
+    mnemonic_file = ctx.params['mnemonic_file']
     if mnemonic_file:
         path = os.path.normpath(f'{os.getcwd()}/{mnemonic_file}')
-        f = open(path, 'a')
+        f = open(path, 'w')
         f.write(mnemonic)
         f.close()
+        ctx.obj['mnemonic_path'] = path
     else:
         test_mnemonic = ''
         while mnemonic != reconstruct_mnemonic(test_mnemonic, WORD_LISTS_PATH):
@@ -66,7 +67,8 @@ def new_mnemonic(ctx: click.Context, mnemonic_language: str, **kwargs: Any) -> N
             click.clear()
             test_mnemonic = click.prompt(load_text(['msg_mnemonic_retype_prompt']) + '\n\n')
         click.clear()
-    # Do NOT use mnemonic_password.
-    ctx.obj = {'mnemonic': mnemonic, 'mnemonic_password': ''}
+
+    ctx.obj['mnemonic'] = mnemonic
+    ctx.obj['mnemonic_password'] = '' # Do NOT use mnemonic_password.
     ctx.params['validator_start_index'] = 0
     ctx.forward(generate_keys)


### PR DESCRIPTION
## Command: new-mnemonic
- Add option `--mnemonic-file` in order to store the mnemonic in file + Disable confirmation

ex: `./deposit.sh --language English new-mnemonic --num_validators 1 --mnemonic_language English --chain lukso --keystore_password password  --mnemonic_file seed.txt`

## Command: existing-mnemonic
- Disable 2nd confirmation of `validator_start_index `(show even if the option is set)

ex: `./deposit.sh --language English existing-mnemonic --num_validators 1 --chain lukso  --validator_start_index 0 --keystore_password password --mnemonic="$(cat seed.txt)"`