### PR TITLE
fix: Revert python 3.11.4 because it has breaking changes. They were documented only on Mac but are on all platforms.

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -99,13 +99,13 @@ jobs:
         if: ${{ matrix.os != 'macos' }}
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11.4
+          python-version: 3.11.3
           architecture: x64
       - name: Set up Python
         if: ${{ matrix.os == 'macos' }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11.4"
+          python-version: "3.11.3"
       - name: Install and build universal2 requirements on macos
         if: ${{ matrix.os == 'macos' }}
         run: |

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -99,7 +99,7 @@ jobs:
         if: ${{ matrix.os != 'macos' }}
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11.3
+          python-version: "3.11.3"
           architecture: x64
       - name: Set up Python
         if: ${{ matrix.os == 'macos' }}
@@ -118,9 +118,9 @@ jobs:
           export PYTHONPATH=./build/pytemps:.:$(python3 -c "import sys;print(':'.join(sys.path))")
           python3 -m pip install -U cython==0.29.33 --no-binary :all:
           python3 -m pip install cytoolz==0.12.2 --no-binary :all: --target ./build/pytemps
-          python3 -m pip install $VERSION --target ./build/pytemps
+          python3 -m pip install $VERSION --no-binary :all: --target ./build/pytemps
           python3 -m pip install -r ./build_configs/macos/requirements.txt --target ./build/pytemps
-          python3 -m pip install -U -r ./build_configs/macos/requirements.pyinstaller.txt
+          python3 -m pip install -U pyinstaller>=5.9.0
           pyinstaller --distpath ./${{ env.BUILD_FILE_NAME }} ./build_configs/macos/build.spec;
       - name: Install building requirements on ${{ matrix.os }}
         if: ${{ matrix.os != 'macos' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.4-alpine
+FROM python:3.11.3-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Now that the GUI was compiled and worked on the Mac I noticed that the python build on ubuntu was no longer working. So I went back to the CLI to notice many of the python builds were affected by the breaking changes in the latest version of python. Unfortunately those problems no longer show up as errors at build time, but the build output cannot be executed.

- [x] Tested ubuntu pyinstaller package
- [x] Tested mac universal pyinstall package
  - [x] Running rosetta x86_64
  - [x] Running native arm64
- [x] Tested windows pyinstaller package
- [x] Tested docker container
  - [x] Tested linux/amd64
  - [x] Tested linux/arm64
  - [x] Tested linux/arm/v7 (colima running under qemu)
     